### PR TITLE
Add Binder badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/kir0ul/escape-from-automanual-testing/master?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Zac-HD/escape-from-automanual-testing/master?urlpath=lab)
 
 # Escape from automanual testing with Hypothesis!
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/kir0ul/escape-from-automanual-testing/master?filepath=lab)
+
 # Escape from automanual testing with Hypothesis!
 
 A three-hour workshop on property-based testing with [Hypothesis](https://hypothesis.works),

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/kir0ul/escape-from-automanual-testing/master?filepath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/kir0ul/escape-from-automanual-testing/master?urlpath=lab)
 
 # Escape from automanual testing with Hypothesis!
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=5.4.3
+hypothesis>=5.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pytest>=5.4.3
 hypothesis>=5.19.0
+numpy>=1.19.0
+pandas>=1.0.5


### PR DESCRIPTION
This is what I had before the last commit when you click on the Binder badge on the README:

![binder](https://user-images.githubusercontent.com/6053592/87229667-04aa8f80-c378-11ea-80cb-7dbf6ef49a94.png)

I changed the Binder URL to point to the `Zac-HD` repo, so it still runs but since the `requirements.txt` file doesn't exists (yet) in this repo, PyTest and Hypothesis are not installed when you get on Binder.